### PR TITLE
Creating asset structure in Galore using the tool throws an error i.e…

### DIFF
--- a/GaloreWCFSample/GaloreWCFSample/GaloreAssetCreator.cs
+++ b/GaloreWCFSample/GaloreWCFSample/GaloreAssetCreator.cs
@@ -45,6 +45,7 @@ namespace Kognifai.Galore.Sample
 
                     command.Attributes.Add("nodeType", nodeType);
                     command.ContextSelector = currentcontext;
+                    command.User = "admin";
 
                     await _configService.ExecuteAsync(new List<Command>() { command }); //This call will create an asset node in Galore.
 


### PR DESCRIPTION
Creating asset structure in Galore using the tool throws an error i.e. "User does not own node(s)".